### PR TITLE
Add Swagger UI Integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <module>client-apis</module>
         <module>driver-app</module>
         <module>tools/maven-archetype</module>
+        <module>tools/swagger-ui-integration</module>
     </modules>
 
     <properties>

--- a/tools/swagger-ui-integration/pom.xml
+++ b/tools/swagger-ui-integration/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.gspatace</groupId>
+    <artifactId>blizzard-restsdk</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <groupId>com.gspatace</groupId>
+  <artifactId>blizzard-swagger-ui-integration</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>blizzard-swagger-ui-integration</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <version>2.3.4.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-boot-starter</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>2.3.4.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-swagger-ui</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>5.2.9.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>com.gspatace</groupId>
+      <artifactId>blizzard-wow-creature-api</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.gspatace</groupId>
+      <artifactId>blizzard-auction-house-client</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-commons</artifactId>
+      <version>2.3.4.RELEASE</version>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.12</version>
+    </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.12</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/App.java
+++ b/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/App.java
@@ -1,0 +1,13 @@
+package com.gspatace.blizzard.swagger.integration;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class App 
+{
+    public static void main( String[] args )
+    {
+        SpringApplication.run(App.class, args);
+    }
+}

--- a/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/apis/AbstractApi.java
+++ b/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/apis/AbstractApi.java
@@ -1,0 +1,22 @@
+package com.gspatace.blizzard.swagger.integration.apis;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+
+@Slf4j
+public abstract class AbstractApi {
+    protected String getContent(String specificationFile) {
+        StringBuilder specification = new StringBuilder();
+        try (Stream<String> lines = Files.lines(Paths.get(ClassLoader.getSystemResource(specificationFile).toURI()))) {
+            lines.forEach(line -> specification.append(line).append(System.lineSeparator()));
+        } catch (URISyntaxException | IOException ex) {
+            log.error("Exception occurred while parsing specification file {} :", specificationFile, ex);
+        }
+        return specification.toString();
+    }
+}

--- a/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/apis/AuctionHouseApi.java
+++ b/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/apis/AuctionHouseApi.java
@@ -1,0 +1,24 @@
+package com.gspatace.blizzard.swagger.integration.apis;
+
+import com.gspatace.blizzard.swagger.integration.intf.DiscoverableResource;
+import com.gspatace.blizzard.swagger.integration.intf.SwaggerResource;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@SwaggerResource
+public class AuctionHouseApi extends AbstractApi implements DiscoverableResource {
+
+    private static final String SPECIFICATION_FILE = "auction_house_openapi_spec.yaml";
+
+    @Override
+    @GetMapping("/auction-house")
+    public String getOpenApiSpec() {
+        return getContent(SPECIFICATION_FILE);
+    }
+
+    @Override
+    public String getName() {
+        return "Auction House";
+    }
+}

--- a/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/apis/CreatureApi.java
+++ b/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/apis/CreatureApi.java
@@ -1,0 +1,24 @@
+package com.gspatace.blizzard.swagger.integration.apis;
+
+import com.gspatace.blizzard.swagger.integration.intf.DiscoverableResource;
+import com.gspatace.blizzard.swagger.integration.intf.SwaggerResource;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@SwaggerResource
+public class CreatureApi extends AbstractApi implements DiscoverableResource {
+
+    private static final String SPECIFICATION_FILE = "wow_creature_api_openapi_spec.yaml";
+
+    @Override
+    public String getName() {
+        return "Creature";
+    }
+
+    @Override
+    @GetMapping("/creature")
+    public String getOpenApiSpec() {
+        return getContent(SPECIFICATION_FILE);
+    }
+}

--- a/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/configuration/RestConfiguration.java
+++ b/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/configuration/RestConfiguration.java
@@ -1,0 +1,14 @@
+package com.gspatace.blizzard.swagger.integration.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestConfiguration {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/configuration/SpringFoxConfiguration.java
+++ b/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/configuration/SpringFoxConfiguration.java
@@ -1,0 +1,20 @@
+package com.gspatace.blizzard.swagger.integration.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SpringFoxConfiguration {
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.OAS_30)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build();
+    }
+}

--- a/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/configuration/SwaggerUIEndpointsConfiguration.java
+++ b/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/configuration/SwaggerUIEndpointsConfiguration.java
@@ -1,0 +1,37 @@
+package com.gspatace.blizzard.swagger.integration.configuration;
+
+import com.gspatace.blizzard.swagger.integration.model.ResourceData;
+import com.gspatace.blizzard.swagger.integration.services.ApiDiscoveryService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.web.client.RestTemplate;
+import springfox.documentation.swagger.web.InMemorySwaggerResourcesProvider;
+import springfox.documentation.swagger.web.SwaggerResource;
+import springfox.documentation.swagger.web.SwaggerResourcesProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+public class SwaggerUIEndpointsConfiguration {
+
+    @Primary
+    @Bean
+    public SwaggerResourcesProvider swaggerResourcesProvider() {
+        final ApiDiscoveryService apiDiscoveryService = new ApiDiscoveryService();
+        final List<ResourceData> apis = apiDiscoveryService.getResources();
+        return () -> {
+            final List<SwaggerResource> resources = new ArrayList<>();
+
+            apis.stream().forEach( res -> {
+                final SwaggerResource swaggerResource = new SwaggerResource();
+                swaggerResource.setName(res.getName());
+                swaggerResource.setLocation(res.getEndpoint());
+                resources.add(swaggerResource);
+            });
+
+            return resources;
+        };
+    }
+}

--- a/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/intf/DiscoverableResource.java
+++ b/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/intf/DiscoverableResource.java
@@ -1,0 +1,6 @@
+package com.gspatace.blizzard.swagger.integration.intf;
+
+public interface DiscoverableResource {
+    String getName();
+    String getOpenApiSpec();
+}

--- a/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/intf/SwaggerResource.java
+++ b/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/intf/SwaggerResource.java
@@ -1,0 +1,4 @@
+package com.gspatace.blizzard.swagger.integration.intf;
+
+public @interface SwaggerResource {
+}

--- a/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/model/ResourceData.java
+++ b/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/model/ResourceData.java
@@ -1,0 +1,14 @@
+package com.gspatace.blizzard.swagger.integration.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class ResourceData {
+    private final String name;
+    private final String endpoint;
+    private final String openApiSpec;
+}

--- a/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/services/ApiDiscoveryService.java
+++ b/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/services/ApiDiscoveryService.java
@@ -1,0 +1,45 @@
+package com.gspatace.blizzard.swagger.integration.services;
+
+
+import com.gspatace.blizzard.swagger.integration.intf.DiscoverableResource;
+import com.gspatace.blizzard.swagger.integration.intf.SwaggerResource;
+import com.gspatace.blizzard.swagger.integration.model.ResourceData;
+import lombok.extern.slf4j.Slf4j;
+import org.reflections.Reflections;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.*;
+
+@Slf4j
+public class ApiDiscoveryService {
+    public List<ResourceData> getResources() {
+        final List<ResourceData> resourceDataList = new ArrayList<>();
+        final Reflections reflections = new Reflections("com.gspatace.blizzard.swagger.integration.apis");
+        final Set<Class<?>> apis = reflections.getTypesAnnotatedWith(SwaggerResource.class);
+        apis.forEach(clazz -> {
+            final Optional<ResourceData> resourceData = getResourceDataFromClazz(clazz);
+            resourceData.ifPresent(res -> {
+                resourceDataList.add(res);
+                log.info("Registered API {} at {} path.", res.getName(), res.getEndpoint());
+            });
+        });
+        return resourceDataList;
+    }
+
+    private Optional<ResourceData> getResourceDataFromClazz(Class<?> clazz) {
+        try {
+            final Constructor<?> constructor = clazz.getConstructor();
+            final DiscoverableResource api = (DiscoverableResource) constructor.newInstance();
+            final Method method = clazz.getMethod("getOpenApiSpec");
+            final GetMapping annotation = method.getAnnotation(GetMapping.class);
+            final String endpoint = Arrays.stream(annotation.value()).findFirst().orElse("");
+            return Optional.of(ResourceData.builder().name(api.getName()).endpoint(endpoint).openApiSpec(api.getOpenApiSpec()).build());
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException ex) {
+            log.error("Exception occurred while parsing Discovered Class {}", clazz.getName(), ex);
+            return Optional.empty();
+        }
+    }
+}

--- a/tools/swagger-ui-integration/src/main/resources/application.yml
+++ b/tools/swagger-ui-integration/src/main/resources/application.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8014


### PR DESCRIPTION
Add Swagger UI Application so that APIs can be analyzed and tested in a friendly manner.
How it works:
- For each client API Package, a REST endpoint is added, which just retrieves the specification file of the client package.
- This endpoint is added as a Swagger Resource in the SwaggerUI, so it can be rendered and used by Swagger UI