### PR TITLE
Add API for Blizzard`s /oauth/userinfo endpoint

### DIFF
--- a/client-apis/blizzard-oauth2/pom.xml
+++ b/client-apis/blizzard-oauth2/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+    <artifactId>blizzard-restsdk-clients</artifactId>
+    <groupId>com.gspatace</groupId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+    <artifactId>blizzard-oauth2</artifactId>
+    <groupId>com.gspatace</groupId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>4.2.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/blizzard_oauth2_openapi_spec.yaml</inputSpec>
+                            <generatorName>java</generatorName>
+                            <library>resttemplate</library>
+                            <configOptions>
+                                <dateLibrary>java8</dateLibrary>
+                            </configOptions>
+                            <invokerPackage>com.gspatace.blizzard.oauth2</invokerPackage>
+                            <apiPackage>com.gspatace.blizzard.oauth2.api</apiPackage>
+                            <modelPackage>com.gspatace.blizzard.oauth2.model</modelPackage>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/client-apis/blizzard-oauth2/src/main/resources/blizzard_oauth2_openapi_spec.yaml
+++ b/client-apis/blizzard-oauth2/src/main/resources/blizzard_oauth2_openapi_spec.yaml
@@ -8,7 +8,7 @@ info:
   version: 0.0.1
 servers:
   - url: "https://eu.battle.net"
-  - url: "https://eu.battle.net"
+  - url: "https://us.battle.net"
 tags:
   - name: "Blizzard Oauth2/Profile"
     description: "REST Client SDK to consume Blizzard`s Oauth2/Profile API endpoint(s)"

--- a/client-apis/blizzard-oauth2/src/main/resources/blizzard_oauth2_openapi_spec.yaml
+++ b/client-apis/blizzard-oauth2/src/main/resources/blizzard_oauth2_openapi_spec.yaml
@@ -10,8 +10,8 @@ servers:
   - url: "https://eu.battle.net"
   - url: "https://eu.battle.net"
 tags:
-  - name: "Creature API"
-    description: "REST Client SDK to consume Blizzard`s Creature API endpoint(s)"
+  - name: "Blizzard Oauth2/Profile"
+    description: "REST Client SDK to consume Blizzard`s Oauth2/Profile API endpoint(s)"
 paths:
   /oauth/userinfo:
     get:

--- a/client-apis/blizzard-oauth2/src/main/resources/blizzard_oauth2_openapi_spec.yaml
+++ b/client-apis/blizzard-oauth2/src/main/resources/blizzard_oauth2_openapi_spec.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+info:
+  title: "Blizzard Profile public API wrapper"
+  description: "Auto-generated SDK API wrapper on top of Blizzard Profile public APIs "
+  contact:
+    name: "George Spatacean"
+    email: "george.spatacean@gmail.com"
+  version: 0.0.1
+servers:
+  - url: "https://eu.battle.net"
+  - url: "https://eu.battle.net"
+tags:
+  - name: "Creature API"
+    description: "REST Client SDK to consume Blizzard`s Creature API endpoint(s)"
+paths:
+  /oauth/userinfo:
+    get:
+      tags:
+        - "user"
+      operationId: "getUserInfo"
+      responses:
+        200:
+          description: "Details of a valid user"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/userInfoResponse"
+      security:
+        - blizzard_auth: []
+        - access_token: []
+components:
+  schemas:
+    userInfoResponse:
+      type: "object"
+      properties:
+        sub:
+          type: "string"
+        id:
+          type: "integer"
+          format: "int64"
+        battletag:
+          type: "string"
+  securitySchemes:
+    blizzard_auth:
+      type: "oauth2"
+      flows:
+        authorizationCode:
+          authorizationUrl: "https://eu.battle.net/oauth/authorize"
+          tokenUrl: "https://eu.battle.net/oauth/token"
+          scopes: {}
+    access_token:
+      type: "apiKey"
+      in: "query"
+      name: "access_token"

--- a/client-apis/pom.xml
+++ b/client-apis/pom.xml
@@ -156,6 +156,7 @@
     <modules>
         <module>auction-house-client</module>
     <module>blizzard-wow-creature-api</module>
+    <module>blizzard-oauth2</module>
   </modules>
 
 </project>

--- a/clients-apis-all/pom.xml
+++ b/clients-apis-all/pom.xml
@@ -15,6 +15,11 @@
         <dependencies>
             <dependency>
                 <groupId>com.gspatace</groupId>
+                <artifactId>blizzard-oauth2</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>com.gspatace</groupId>
                 <artifactId>blizzard-wow-creature-api</artifactId>
                 <version>1.0-SNAPSHOT</version>
             </dependency>
@@ -27,6 +32,10 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>com.gspatace</groupId>
+            <artifactId>blizzard-oauth2</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.gspatace</groupId>
             <artifactId>blizzard-wow-creature-api</artifactId>

--- a/driver-app/src/main/java/com/gspatace/blizzard/driver/app/App.java
+++ b/driver-app/src/main/java/com/gspatace/blizzard/driver/app/App.java
@@ -3,6 +3,7 @@ package com.gspatace.blizzard.driver.app;
 import com.gspatace.blizzard.auctionhouse.ApiClient;
 import com.gspatace.blizzard.auctionhouse.api.AuctionHouseApi;
 import com.gspatace.blizzard.auctionhouse.model.AuctionsApiResponse;
+import com.gspatace.blizzard.oauth2.api.UserApi; //NOSONAR
 import lombok.extern.slf4j.Slf4j;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.springframework.boot.CommandLineRunner;
@@ -54,9 +55,16 @@ public class App implements CommandLineRunner {
             log.error("Exception occurred:", ex);
         }
 
-        String accessToken = oAuthRestTemplate().getAccessToken().getValue();
-        CreatureAPIDriver creatureAPIDriver = new CreatureAPIDriver();
+        final String accessToken = oAuthRestTemplate().getAccessToken().getValue();
+        final CreatureAPIDriver creatureAPIDriver = new CreatureAPIDriver();
         creatureAPIDriver.doTest(accessToken);
+
+        /**
+         * This API requires Authorization Code flow, keep it disabled
+         * and provide a manual token when desired
+         */
+        //final UserInfoAPIDriver userInfoAPIDriver = new UserInfoAPIDriver(); //NOSONAR
+        //userInfoAPIDriver.doTest("EUSRahKKtNEjM9lYhzdhAiR6lxqXltMv2m"); //NOSONAR
     }
 }
 

--- a/driver-app/src/main/java/com/gspatace/blizzard/driver/app/UserInfoAPIDriver.java
+++ b/driver-app/src/main/java/com/gspatace/blizzard/driver/app/UserInfoAPIDriver.java
@@ -1,0 +1,26 @@
+package com.gspatace.blizzard.driver.app;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gspatace.blizzard.oauth2.ApiClient;
+import com.gspatace.blizzard.oauth2.api.UserApi;
+import com.gspatace.blizzard.oauth2.model.UserInfoResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class UserInfoAPIDriver {
+    public void doTest(String accessToken){
+        final ApiClient apiClient = new ApiClient();
+        apiClient.setAccessToken(accessToken);
+
+        final UserApi userApi = new UserApi(apiClient);
+        final UserInfoResponse userInfo = userApi.getUserInfo();
+        final ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            final String response = objectMapper.writeValueAsString(userInfo);
+            log.info("User Info API Response: {}", response);
+        } catch (JsonProcessingException e) {
+            log.error("Error occurred:", e);
+        }
+    }
+}

--- a/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/apis/Oauth2API.java
+++ b/tools/swagger-ui-integration/src/main/java/com/gspatace/blizzard/swagger/integration/apis/Oauth2API.java
@@ -1,0 +1,23 @@
+package com.gspatace.blizzard.swagger.integration.apis;
+
+import com.gspatace.blizzard.swagger.integration.intf.DiscoverableResource;
+import com.gspatace.blizzard.swagger.integration.intf.SwaggerResource;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@SwaggerResource
+public class Oauth2API extends AbstractApi implements DiscoverableResource {
+
+    private static final String SPECIFICATION_FILE= "blizzard_oauth2_openapi_spec.yaml";
+    @Override
+    public String getName() {
+        return "Blizzard Oauth2";
+    }
+
+    @Override
+    @GetMapping("/blizzard-oauth2")
+    public String getOpenApiSpec() {
+        return getContent(SPECIFICATION_FILE);
+    }
+}


### PR DESCRIPTION
Add API for Blizzard`s /oauth/userinfo endpoint, which just retrieves minimum information about the owner of an access_token …

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>